### PR TITLE
Fixed 'artifact' in PhysicistGameScreen

### DIFF
--- a/Physicist/Physicist/Controls/Interfaces/IPhysicistGameScreen.cs
+++ b/Physicist/Physicist/Controls/Interfaces/IPhysicistGameScreen.cs
@@ -3,12 +3,10 @@
     using FarseerPhysics.Dynamics;
     using Physicist.Actors;
 
-    public interface IPhysicistRegistration
+    public interface IPhysicistGameScreen
     {
         World World { get; }
 
         Map Map { get; }
-
-        void RegisterActor(Actor actor);
     }
 }

--- a/Physicist/Physicist/Controls/Map/Maploader.cs
+++ b/Physicist/Physicist/Controls/Map/Maploader.cs
@@ -24,7 +24,7 @@
         private static Dictionary<string, Type> assemblyTypes = new Dictionary<string, Type>();
         private static Dictionary<string, Type> quantifiedAssemblyTypes = new Dictionary<string, Type>();
 
-        private static IPhysicistRegistration registration = null;
+        private static IPhysicistGameScreen registration = null;
 
         private static XElement rootElement = null;
         private static XmlSchemaSet schemas = new XmlSchemaSet();
@@ -96,7 +96,7 @@
             private set;
         }
 
-        public static Map Initialize(string filePath, IPhysicistRegistration registrationObject)
+        public static Map Initialize(string filePath, IPhysicistGameScreen registrationObject)
         {
             MapLoader.CurrentMap = null;
             MapLoader.HasFailed = false;

--- a/Physicist/Physicist/Controls/Screens/PhysicistGameScreen.cs
+++ b/Physicist/Physicist/Controls/Screens/PhysicistGameScreen.cs
@@ -12,12 +12,11 @@
     using Microsoft.Xna.Framework.Input;
     using Physicist.Actors;
 
-    public class PhysicistGameScreen : GameScreen, IPhysicistRegistration
+    public class PhysicistGameScreen : GameScreen, IPhysicistGameScreen
     {
         private World world;
         private Map map;
 
-        private List<Actor> actors;
         private List<string> maps;
         private string mapPath;
 
@@ -46,7 +45,6 @@
         public override void Initialize(GraphicsDevice graphicsDevice)
         {
             base.Initialize(graphicsDevice);
-            this.actors = new List<Actor>();
             this.maps = new List<string>() { this.mapPath };
 
             ConvertUnits.SetDisplayUnitToSimUnitRatio(2f);
@@ -88,11 +86,6 @@
 
                 this.World.Step((float)gameTime.ElapsedGameTime.TotalMilliseconds * 0.001f);
 
-                foreach (var actor in this.actors)
-                {
-                    actor.Update(gameTime);
-                }
-
                 // TODO: Add your update logic here
                 this.map.Update(gameTime);
             }
@@ -102,7 +95,6 @@
 
         public override void Draw(ISpritebatch sb)
         {
-            this.actors.ForEach(actor => actor.Draw(sb));
             this.map.Draw(sb);
 
             base.Draw(sb);
@@ -112,11 +104,6 @@
         {
             this.map.UnloadMedia();
             base.UnloadContent();
-        }
-
-        public void RegisterActor(Actor actor)
-        {
-            this.actors.Add(actor);
         }
     }
 }

--- a/Physicist/Physicist/Physicist.csproj
+++ b/Physicist/Physicist/Physicist.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Controls\Interfaces\IPosition.cs" />
     <Compile Include="Controls\Interfaces\IUpdate.cs" />
     <Compile Include="Controls\Interfaces\IXmlSerializable.cs" />
-    <Compile Include="Controls\Interfaces\IPhysicistRegistration.cs" />
+    <Compile Include="Controls\Interfaces\IPhysicistGameScreen.cs" />
     <Compile Include="Controls\Map\MapObject.cs" />
     <Compile Include="Controls\Map\BackgroundMusic.cs" />
     <Compile Include="Controls\Map\Backdrop.cs" />


### PR DESCRIPTION
Derek spotted some older code that I had in the PhysicistGameScreen that somehow got pushed along when I merge them. It didn't cause any major issues, yet, but it was drawing/updating the actors twice. This should fix the issue and clear up confusion about where object references items within a given map are stored. 
